### PR TITLE
build acts here as a submodule so it can change as dev progresses

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "acts"]
+	path = acts
+	url = git@github.com:acts-project/acts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,6 @@ project(Tracking VERSION 2.1.0
 # Search for ROOT and add all targets.
 find_package(ROOT CONFIG REQUIRED)
 
-find_package(Acts CONFIG REQUIRED COMPONENTS Core PluginDD4hep)
-
-find_package(Eigen3 CONFIG REQUIRED)
-
-setup_dd4hep_target()
-
-setup_geant4_target()
-
 # Allow building of event specific classes only.  The most common use case is 
 # needing to build the event classes to allow building of the event bus and ROOT
 # dictionary prior building the rest of the modules in a package. 
@@ -28,30 +20,45 @@ if(BUILD_EVENT_ONLY)
 
     # Register all of the classes with the event bus.
     register_event_object(module_path "Tracking/Event" 
-	                  namespace "ldmx" 
-	                  class "RawSiStripHit" )
+                    namespace "ldmx" 
+                    class "RawSiStripHit" )
 
     register_event_object(module_path "Tracking/Event" 
-	                  namespace "ldmx" 
-	                  class "Track" type "collection")
+                    namespace "ldmx" 
+                    class "Track" type "collection")
 
-			
+      
 
     # Get all of the event sources that will be included in this library
     file(GLOB EVENT_SRC_FILES CONFIGURE_DEPENDS 
-	      ${PROJECT_SOURCE_DIR}/src/Tracking/Event/[a-zA-z]*.cxx)
+        ${PROJECT_SOURCE_DIR}/src/Tracking/Event/[a-zA-z]*.cxx)
 
     # Generate the files needed to build the event classes.
     setup_library(module Tracking
                   name Event
                   dependencies ROOT::Core
-		  ActsCore
-		  Geant4::Interface
                   sources ${EVENT_SRC_FILES}
                   register_target)
 
      return()
 endif()
+
+# since ACTS changes frequently enough, we build it as a submodule of Tracking
+#   here we 'set' some CMake variables that we would have passed to 'cmake' on
+#   the command line with '-D' if we were building ACTS directly.
+set(ACTS_BUILD_PLUGIN_DD4HEP ON) # representing geometry with DD4hep right now
+set(ACTS_BUILD_EXAMPLES OFF)     # don't waste time building examples
+set(CMAKE_CXX_STANDARD 17)       # set C++ standard we use within ldmx-sw
+add_subdirectory(acts)           # now build acts
+# luckily for us, adding ACTS as a subdirectory produces the same CMake targets
+#   as find_package, so we don't need to do anything else from here on out
+
+find_package(Eigen3 CONFIG REQUIRED)
+
+setup_dd4hep_target()
+
+setup_geant4_target()
+
 
 file(GLOB SRC_FILES CONFIGURE_DEPENDS 
   ${PROJECT_SOURCE_DIR}/src/Tracking/Sim/[a-zA-z]*.cxx
@@ -62,16 +69,17 @@ file(GLOB SRC_FILES CONFIGURE_DEPENDS
 setup_library(module Tracking
               dependencies Framework::Configure 
                            Framework::Framework 
-			   ActsCore
-			   ActsPluginDD4hep
-			   DD4hep::DDCore
-			   sources ${SRC_FILES})
+                           ActsCore
+                           ActsPluginDD4hep
+                           Geant4::Interface
+                           DD4hep::DDCore
+              sources ${SRC_FILES})
 
 
 include_directories(${PROJECT_SOURCE_DIR}/include/Tracking/Reco/)
-			 
+
 setup_python(package_name ${PYTHON_PACKAGE_NAME}/Tracking)
 
 #Setup the test
 setup_test(dependencies Tracking::Tracking)
-			
+      


### PR DESCRIPTION
- include acts as a submodule of this repository
- update CMakeLists to build acts with the same options set as would be
  given on the command line
- clean up tabbing within CMakeLists
- use v18.0.0 of acts