### PR TITLE
Migrate to ACTS v23.5.0

### DIFF
--- a/include/Tracking/Reco/CKFProcessor.h
+++ b/include/Tracking/Reco/CKFProcessor.h
@@ -66,6 +66,8 @@
 #include "Acts/TrackFinding/CombinatorialKalmanFilter.hpp"
 #include "Acts/EventData/MultiTrajectory.hpp"
 #include "Acts/EventData/MultiTrajectoryHelpers.hpp"
+#include "Acts/EventData/VectorTrackContainer.hpp"
+
 
 //--- Refit with backward propagation ---//
 #include "Acts/TrackFitting/KalmanFitter.hpp"
@@ -170,7 +172,7 @@ class CKFProcessor final : public framework::Producer {
   // Make a simple event display
   void writeEvent(framework::Event &event,
 		  const Acts::BoundTrackParameters& perigeeParameters,
-		  const Acts::MultiTrajectory& mj,
+		  const Acts::MultiTrajectory<Acts::VectorMultiTrajectory>& mj,
                   const int& trackTip,
                   const std::vector<ldmx::Measurement> meas);
 
@@ -262,13 +264,13 @@ class CKFProcessor final : public framework::Producer {
   std::unique_ptr<const CkfPropagator> propagator_;
 
   //The CKF
-  std::unique_ptr<const Acts::CombinatorialKalmanFilter<CkfPropagator>> ckf_;
+  std::unique_ptr<const Acts::CombinatorialKalmanFilter<CkfPropagator,Acts::VectorMultiTrajectory>> ckf_;
 
   //The KF
-  std::unique_ptr<const Acts::KalmanFitter<CkfPropagator>> kf_;
+  std::unique_ptr<const Acts::KalmanFitter<CkfPropagator,Acts::VectorMultiTrajectory>> kf_;
 
   //The GSF Fitter
-  std::unique_ptr<const Acts::GaussianSumFitter<GsfPropagator>> gsf_;
+  //std::unique_ptr<const Acts::GaussianSumFitter<GsfPropagator>> gsf_;
   
   //The propagator steps writer
   std::unique_ptr<tracking::sim::PropagatorStepWriter> writer_;

--- a/include/Tracking/Reco/SeedFinderProcessor.h
+++ b/include/Tracking/Reco/SeedFinderProcessor.h
@@ -99,16 +99,7 @@ class SeedFinderProcessor : public framework::Producer {
   Acts::MagneticFieldContext bctx_;
   Acts::CalibrationContext cctx_;
 
-  Acts::SpacePointGridConfig grid_conf_;
-  Acts::SeedfinderConfig<ldmx::LdmxSpacePoint> config_;
-  Acts::SeedFilterConfig seed_filter_cfg_;
   Acts::Vector3 bField_;
-
-  // Acts::Seedfinder::State state_;
-
-  std::shared_ptr<Acts::Seedfinder<ldmx::LdmxSpacePoint>> seed_finder_;
-  std::shared_ptr<Acts::BinFinder<ldmx::LdmxSpacePoint>> bottom_bin_finder_;
-  std::shared_ptr<Acts::BinFinder<ldmx::LdmxSpacePoint>> top_bin_finder_;
 
   /* This is a temporary (working) solution to estimate the track parameters out
    * of the seeds Eventually we should move to what is in ACTS (I'm not happy

--- a/include/Tracking/Sim/GeometryContainers.h
+++ b/include/Tracking/Sim/GeometryContainers.h
@@ -8,16 +8,16 @@
 
 #pragma once
 
+#include "Acts/EventData/SourceLink.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
-//#include "ActsExamples/Utilities/GroupBy.hpp"
-//#include "ActsExamples/Utilities/Range.hpp"
-
+#include "Acts/Surfaces/Surface.hpp"
 #include "Tracking/Sim/GroupBy.h"
 #include "Tracking/Sim/Range.h"
 
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <iostream>
 #include <utility>
 
 #include <boost/container/flat_map.hpp>
@@ -227,22 +227,7 @@ struct GeometryIdMultisetAccessor {
 
   // pointer to the container
   const Container* container = nullptr;
-
-  // count the number of elements with requested geoId
-  size_t count(const Acts::GeometryIdentifier& geoId) const {
-    assert(container != nullptr);
-    return container->count(geoId);
-  }
-
-  // get the range of elements with requested geoId
-  std::pair<Iterator, Iterator> range(
-      const Acts::GeometryIdentifier& geoId) const {
-    assert(container != nullptr);
-    return container->equal_range(geoId);
-  }
-
-  // get the element using the iterator
-  const Value& at(const Iterator& it) const { return *it; }
 };
+
 
 }  // namespace ActsExamples

--- a/include/Tracking/Sim/IndexSourceLink.h
+++ b/include/Tracking/Sim/IndexSourceLink.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/EventData/SourceLink.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 
 #include "Tracking/Sim/GeometryContainers.h"
 #include "Tracking/Sim/Index.h"
@@ -26,15 +27,15 @@ namespace ActsExamples {
 /// Using an index instead of e.g. a pointer, means source link and
 /// measurement are decoupled and the measurement represenation can be
 /// easily changed without having to also change the source link.
-class IndexSourceLink final : public Acts::SourceLink {
+class IndexSourceLink final {
  public:
   /// Construct from geometry identifier and index.
   constexpr IndexSourceLink(Acts::GeometryIdentifier gid, Index idx)
-      : SourceLink(gid), m_index(idx) {}
+      : m_geometryId(gid), m_index(idx) {}
 
   // Construct an invalid source link. Must be default constructible to
   /// satisfy SourceLinkConcept.
-  IndexSourceLink() : SourceLink{Acts::GeometryIdentifier{}} {}
+  IndexSourceLink() = default;
   IndexSourceLink(const IndexSourceLink&) = default;
   IndexSourceLink(IndexSourceLink&&) = default;
   IndexSourceLink& operator=(const IndexSourceLink&) = default;
@@ -43,16 +44,19 @@ class IndexSourceLink final : public Acts::SourceLink {
   /// Access the index.
   constexpr Index index() const { return m_index; }
 
- private:
-  Index m_index;
+  Acts::GeometryIdentifier geometryId() const { return m_geometryId; }
 
-  friend constexpr bool operator==(const IndexSourceLink& lhs,
-                                   const IndexSourceLink& rhs) {
+ private:
+  Acts::GeometryIdentifier m_geometryId;
+  Index m_index = 0;
+
+  friend bool operator==(const IndexSourceLink& lhs,
+                         const IndexSourceLink& rhs) {
     return (lhs.geometryId() == rhs.geometryId()) and
            (lhs.m_index == rhs.m_index);
   }
-  friend constexpr bool operator!=(const IndexSourceLink& lhs,
-                                   const IndexSourceLink& rhs) {
+  friend bool operator!=(const IndexSourceLink& lhs,
+                         const IndexSourceLink& rhs) {
     return not(lhs == rhs);
   }
 };
@@ -61,13 +65,21 @@ class IndexSourceLink final : public Acts::SourceLink {
 ///
 /// Since the source links provide a `.geometryId()` accessor, they can be
 /// stored in an ordered geometry container.
-using IndexSourceLinkContainer =
-    GeometryIdMultiset<std::reference_wrapper<const IndexSourceLink>>;
+using IndexSourceLinkContainer = GeometryIdMultiset<IndexSourceLink>;
 /// Accessor for the above source link container
 ///
 /// It wraps up a few lookup methods to be used in the Combinatorial Kalman
 /// Filter
-using IndexSourceLinkAccessor =
-    GeometryIdMultisetAccessor<std::reference_wrapper<const IndexSourceLink>>;
+struct IndexSourceLinkAccessor : GeometryIdMultisetAccessor<IndexSourceLink> {
+  using BaseIterator = GeometryIdMultisetAccessor<IndexSourceLink>::Iterator;
 
+  using Iterator = Acts::SourceLinkAdapterIterator<BaseIterator>;
+
+  // get the range of elements with requested geoId
+  std::pair<Iterator, Iterator> range(const Acts::Surface& surface) const {
+    assert(container != nullptr);
+    auto [begin, end] = container->equal_range(surface.geometryId());
+    return {Iterator{begin}, Iterator{end}};
+  }
+};
 }  // namespace ActsExamples

--- a/src/Tracking/Reco/EcalTrackingGeometry.cxx
+++ b/src/Tracking/Reco/EcalTrackingGeometry.cxx
@@ -404,8 +404,8 @@ Acts::CuboidVolumeBuilder::LayerConfig EcalTrackingGeometry::buildLayerConfig(
   double thickness =
       rings.front()->surfaceMaterial()->materialSlab(ploc).thickness();
 
-  lcfg.envelopeX = std::pair<double, double>{thickness / 2. + clearance,
-                                             thickness / 2. + clearance};
+  lcfg.envelopeX = std::array<double, 2>{thickness / 2. + clearance,
+    thickness / 2. + clearance};
   lcfg.active = active;
 
   return lcfg;

--- a/src/Tracking/Reco/SeedFinderProcessor.cxx
+++ b/src/Tracking/Reco/SeedFinderProcessor.cxx
@@ -19,21 +19,7 @@ namespace reco {
 SeedFinderProcessor::SeedFinderProcessor(const std::string& name,
                                          framework::Process& process)
     : framework::Producer(name, process) {
-  // Should be the typical behaviour.
-  int numPhiNeighbors = 1;
-  std::vector<std::pair<int, int>> zBinNeighborsTop;
-  std::vector<std::pair<int, int>> zBinNeighborsBottom;
-
-  bottom_bin_finder_ = std::make_shared<Acts::BinFinder<ldmx::LdmxSpacePoint>>(
-      Acts::BinFinder<ldmx::LdmxSpacePoint>(zBinNeighborsBottom,
-                                            numPhiNeighbors));
-
-  top_bin_finder_ = std::make_shared<Acts::BinFinder<ldmx::LdmxSpacePoint>>(
-      Acts::BinFinder<ldmx::LdmxSpacePoint>(zBinNeighborsTop, numPhiNeighbors));
-
-  seed_to_track_maker_ =
-      std::make_shared<tracking::sim::SeedToTrackParamMaker>();
-
+  
   outputFile_ = new TFile("seeder.root", "RECREATE");
   outputTree_ = new TTree("seeder", "seeder");
 
@@ -58,66 +44,10 @@ void SeedFinderProcessor::onProcessStart() {
 }
 
 void SeedFinderProcessor::configure(framework::config::Parameters& parameters) {
-  // Default configuration
-
-  // Tagger r max
-  config_.rMax = 1000.;
-  config_.deltaRMin = 3.;
-  config_.deltaRMax = 220.;
-  config_.collisionRegionMin = -50;
-  config_.collisionRegionMax = 50;
-  config_.zMin = -300;
-  config_.zMax = 300.;
-  config_.maxSeedsPerSpM = 5;
-
-  // More or less the max angle is something of the order of 50 / 600 (assuming
-  // that the track hits all the layers) Theta for the seeder is like ATLAS eta,
-  // so it's 90-lambda. Max lamba is of the order of ~0.1 so cotThetaMax will
-  // be 1./tan(pi/2 - 0.1) ~ 1.4.
-  config_.cotThetaMax = 1.5;
-
-  // cotThetaMax and deltaRMax matter to choose the binning in z. The bin size
-  // is given by cotThetaMax*deltaRMax
-
-  config_.sigmaScattering = 2.25;
-  config_.minPt = 500. * Acts::UnitConstants::MeV;
-  config_.bFieldInZ = 1.5 * Acts::UnitConstants::T;
-  config_.beamPos = {0, 0};  // units mm ?
-  config_.impactMax = 40.;
-
-  grid_conf_.bFieldInZ = config_.bFieldInZ;
-  grid_conf_.minPt = config_.minPt;
-  grid_conf_.rMax = config_.rMax;
-  grid_conf_.zMax = config_.zMax;
-  grid_conf_.zMin = config_.zMin;
-  grid_conf_.deltaRMax = config_.deltaRMax;
-  grid_conf_.cotThetaMax = config_.cotThetaMax;
-  grid_conf_.impactMax = config_.impactMax;
-  grid_conf_.phiBinDeflectionCoverage = 1.;  // renamed from numPhiNeighbors
-
-  // The seed finder needs a seed filter instance
-  // In the seed finder there is the correction for the beam axis, which you
-  // could ignore if you set the penalty for high impact parameters. So removing
-  // that in the seeder config.
-
-  // Seed filter configuration
-  seed_filter_cfg_.impactWeightFactor = 0.;
-
-  // For the moment no experiment dependent cuts are assigned to the filter
-  config_.seedFilter = std::make_unique<Acts::SeedFilter<ldmx::LdmxSpacePoint>>(
-      Acts::SeedFilter<ldmx::LdmxSpacePoint>(seed_filter_cfg_));
-
-  seed_finder_ =
-      std::make_shared<Acts::Seedfinder<ldmx::LdmxSpacePoint>>(config_);
-
-  // In ACTS coordinates and BField in Tesla
-  bField_(0) = 0.;
-  bField_(1) = 0.;
-  bField_(2) = config_.bFieldInZ;
 
   // Retrieve the path to the GDML description of the detector
   detector_ = parameters.getParameter<std::string>("detector");
-
+  
   out_seed_collection_ = parameters.getParameter<std::string>(
       "out_seed_collection", getName() + "SeedTracks");
   input_hits_collection_ = parameters.getParameter<std::string>(
@@ -159,137 +89,6 @@ void SeedFinderProcessor::produce(framework::Event& event) {
           tracking::sim::utils::convertSimHitToLdmxSpacePoint(simHit));
     }
   }
-
-  /*
-  //ldmx_log(info) << "Converted " << ldmxsps.size() << " hits";
-  //TODO:: For the moemnt I am only selecting 3 points. In principle the grid
-  should be able to find all combinatorics
-  //I'll use layer 3,5,7.
-
-  std::vector<const ldmx::LdmxSpacePoint*> spVec;
-  Acts::Extent rRangeSPExtent;
-
-  for (size_t isp = 0; isp < ldmxsps.size(); isp++) {
-
-    //std::cout<<"isp:"<<isp<<ldmxsps[isp]->layer()<<std::endl;
-
-    int lyID = (ldmxsps[isp]->layer() / 100) % 10;
-    int sID  = (ldmxsps[isp]->layer()) % 2;
-    int layerID = (lyID - 1 ) * 2 + sID;
-
-    //std::cout<<(int) isp<<" "<<(ldmxsps[isp]->layer())<<" "<<lyID<<" "<<sID<<"
-  "<<layerID<<std::endl;
-
-    if (layerID == 3 || layerID == 7 || layerID == 9) {
-      spVec.push_back(ldmxsps[isp]);
-      rRangeSPExtent.check({ldmxsps[isp]->x(), ldmxsps[isp]->y(),
-  ldmxsps[isp]->z()});
-    }
-  }
-
-  //ldmx_log(info) <<"Will use spVec::"<<spVec.size()<<" hits ";
-  //covariance tool: returns the covariance from the space point
-  auto covariance_tool = [=](const ldmx::LdmxSpacePoint& sp, float, float,
-                             float) -> std::pair<Acts::Vector3, Acts::Vector2> {
-    Acts::Vector3 position{sp.x(), sp.y(), sp.z()};
-    Acts::Vector2 covariance{sp.varianceR(), sp.varianceZ()};
-    return std::make_pair(position, covariance);
-  };
-
-  //std::cout<<"Creating the grid"<<std::endl;
-
-  std::unique_ptr<Acts::SpacePointGrid<ldmx::LdmxSpacePoint> > grid =
-  Acts::SpacePointGridCreator::createGrid<ldmx::LdmxSpacePoint>(grid_conf_);
-
-  //std::cout<<"Creating the space point group"<<std::endl;
-
-  // create the space point group
-  auto spGroup = Acts::BinnedSPGroup<ldmx::LdmxSpacePoint>(
-      spVec.begin(), spVec.end(),
-      covariance_tool,
-      bottom_bin_finder_, top_bin_finder_,
-      std::move(grid), config_);
-
-
-  // seed vector
-  using SeedContainer = std::vector<Acts::Seed<ldmx::LdmxSpacePoint>>;
-  SeedContainer seeds;
-  seeds.clear();
-
-  Acts::Seedfinder<ldmx::LdmxSpacePoint>::State state;
-
-  // find the seeds
-  auto group = spGroup.begin();
-  auto group_end = spGroup.end();
-
-  for (; !(group == group_end); ++group) {
-    seed_finder_->createSeedsForGroup(state, std::back_inserter(seeds),
-  group.bottom(), group.middle(), group.top(),rRangeSPExtent);
-  }
-
-  int numSeeds = seeds.size();
-
-  */
-  /*
-
-  for (auto& seed : seeds) {
-
-    auto ldmxspvec = seed.sp();
-
-    //Fit the seeds and extract the track parameters
-
-    //Local Surface (u,v,w) frame (wrt ACTS frame) rotation
-    Acts::Vector3 uaxis{0,0,1};
-    Acts::Vector3 vaxis{0,-1,0};
-    Acts::Vector3 waxis{1,0,0};
-
-    Acts::RotationMatrix3 s_rotation;
-    s_rotation.col(0) = uaxis;
-    s_rotation.col(1) = vaxis;
-    s_rotation.col(2) = waxis;
-
-    //Translation to the reference plane origin
-    //TODO:: Attach the space points to the surfaces and provide the origin on
-  surface.
-
-    //Acts::Vector3 surface_origin{0.,0.,0.};
-    //Acts::Translation3 s_trans(0.,0.,0.); //wrong
-
-    Acts::Vector3 g_pos = ldmxspvec[0]->getGlobalPosition();
-    Acts::Translation3 s_trans(g_pos);
-
-
-    //Build the local to global transform
-    Acts::Transform3 tP(s_trans * s_rotation);
-
-    //TODO:: Correct the 6th parameter (time)
-    auto params = seed_to_track_maker_->estimateTrackParamsFromSeed(tP,
-                                                                    ldmxspvec.begin(),ldmxspvec.end(),
-                                                                    bField_, 1.
-  * Acts::UnitConstants::T, 0.5);
-
-    ldmx::Track trk = ldmx::Track();
-
-    trk.setPerigeeLocation(g_pos(0), g_pos(1), g_pos(2));
-    trk.setChi2(0.);
-    trk.setNhits(3);
-    trk.setNdf(0);
-    trk.setNsharedHits(0);
-
-    if (!params)
-      return;
-
-
-    std::vector<double> v_seed_params((*params).data(), (*params).data() +
-  (*params).rows() * (*params).cols()); std::vector<double> v_seed_cov;
-    tracking::sim::utils::flatCov(Acts::BoundSymMatrix::Identity(), v_seed_cov);
-    trk.setPerigeeParameters(v_seed_params);
-    trk.setPerigeeCov(v_seed_cov);
-
-    //Get momentum and position - TODO
-    seed_tracks.push_back(trk);
-  }
-  */
 
   const std::vector<ldmx::Measurement> measurements =
       event.getCollection<ldmx::Measurement>(input_hits_collection_);

--- a/src/Tracking/Reco/TrackersTrackingGeometry.cxx
+++ b/src/Tracking/Reco/TrackersTrackingGeometry.cxx
@@ -119,8 +119,8 @@ TrackersTrackingGeometry::buildRecoilVolume() {
 
     // std::cout<<"Sensor Thickness from Material slab "<< thickness<<std::endl;
 
-    lcfg.envelopeX = std::pair<double, double>{thickness / 2. + clearance,
-                                               thickness / 2. + clearance};
+    lcfg.envelopeX = std::array<double, 2>{thickness / 2. + clearance,
+      thickness / 2. + clearance};
     lcfg.active = true;
     layerConfig.push_back(lcfg);
   }
@@ -206,8 +206,8 @@ TrackersTrackingGeometry::buildTrackerVolume() {
 
     // std::cout<<"Sensor Thickness from Material slab "<< thickness<<std::endl;
 
-    lcfg.envelopeX = std::pair<double, double>{thickness / 2. + clearance,
-                                               thickness / 2. + clearance};
+    lcfg.envelopeX = std::array<double, 2>{thickness / 2. + clearance,
+      thickness / 2. + clearance};
     lcfg.active = true;
     layerConfig.push_back(lcfg);
   }


### PR DESCRIPTION
This PR closes #50 
It's necessary to keep in line with newer developments of ACTS API as well as important fixes to the navigation in order to get the right hits on surfaces. 

