### PR TITLE
don't setup tests without a test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,3 @@ setup_library(module Tracking
 include_directories(${PROJECT_SOURCE_DIR}/include/Tracking/Reco/)
 
 setup_python(package_name ${PYTHON_PACKAGE_NAME}/Tracking)
-
-#Setup the test
-setup_test(dependencies Tracking::Tracking)
-      


### PR DESCRIPTION
When calling `setup_test`, the CMake infrastructure assumes you have at least one test in the Catch2 test program. So when we end up calling the Catch2 test program, we get an error and fail the tests because there isn't a test from this module in the program.

```
  test 7
      Start 7: Tracking
  
  7: Test command: /home/runner/work/ldmx-sw/ldmx-sw/build/run_test "[Tracking]"
  7: Working Directory: /home/runner/work/ldmx-sw/ldmx-sw/build/test
  7: Test timeout computed to be: 10000000
  7: Filters: [Tracking]
  7: Randomness seeded to: 749200269
  7: No test cases matched '[Tracking]'
  7: ===============================================================================
  7: No tests ran
  7: 
  7/7 Test #7: Tracking .........................***Failed    0.04 sec
```