### PR TITLE
Add Gaussian Sum Filter processor example

### DIFF
--- a/include/Tracking/Event/Track.h
+++ b/include/Tracking/Event/Track.h
@@ -7,6 +7,7 @@
 //----------------------//
 #include <iostream>
 #include <vector>
+#include <optional>
 
 //----------//
 //   ROOT   //
@@ -20,7 +21,6 @@
 
 
 namespace ldmx {
-
 
 
 /// This enum describes the type of TrackState
@@ -38,7 +38,8 @@ enum TrackStateType {
   AtFirstMeasurement    = 2,
   AtLastMeasurement     = 3,
   AtECAL                = 4,
-  Invalid               = 5
+  AtBeamOrigin          = 5,
+  Invalid               = 6
 };
 
 
@@ -64,7 +65,7 @@ class Track {
     std::vector<double> params;
     std::vector<double> cov;
     TrackStateType      ts_type;
-    
+
   };
   
   
@@ -87,9 +88,20 @@ class Track {
   void setNhits(int nhits) {n_hits_ = nhits;}
   int getNhits() const { return n_hits_;}
 
+
+  std::optional<TrackState> getTrackState(TrackStateType tstype) {
+    
+    for (auto ts : trackStates_) 
+      if (ts.ts_type == tstype)
+        return std::optional<TrackState>(ts);
+    
+    return std::nullopt;
+  }
+  
+  
   //void setNholes(int nholes) {n_holes_ = nholes;}
   //int  getNholes() const {return n_holes_;}
-
+  
   void setNoutliers(int nout) {n_outliers_ = nout;}
   int getNoutliers() const {return n_outliers_;}
   

--- a/include/Tracking/Reco/GSFProcessor.h
+++ b/include/Tracking/Reco/GSFProcessor.h
@@ -5,16 +5,12 @@
 #include "Framework/EventProcessor.h"
 #include "Framework/RandomNumberSeedService.h"
 
-//--- Tracking I/O---//
-#include "Tracking/Sim/PropagatorStepWriter.h"
-
 //--- C++ ---//
 #include <random>
 #include <memory>
 
 //--- LDMX ---//
 #include "Tracking/Reco/TrackingGeometryUser.h"
-
 
 //--- ACTS ---//
 
@@ -35,7 +31,6 @@
 
 //geometry
 #include <Acts/Geometry/TrackingGeometry.hpp>
-
 
 //propagation testing
 #include "Acts/Propagator/Navigator.hpp"
@@ -71,7 +66,8 @@
 
 
 //GSF
-//#include "Acts/TrackFitting/GaussianSumFitter.hpp"
+#include "Acts/TrackFitting/BetheHeitlerApprox.hpp"
+#include "Acts/TrackFitting/GaussianSumFitter.hpp"
 #include "Acts/Propagator/MultiEigenStepperLoop.hpp"
 
 //--- Tracking ---//
@@ -89,23 +85,24 @@
 using ActionList = Acts::ActionList<Acts::detail::SteppingLogger, Acts::MaterialInteractor>;
 using AbortList = Acts::AbortList<Acts::EndOfWorldReached>;
 
-using CkfPropagator = Acts::Propagator<Acts::EigenStepper<>, Acts::Navigator>;
-using GsfPropagator = Acts::Propagator<
-                        Acts::MultiEigenStepperLoop<
-                          Acts::StepperExtensionList<
-                            Acts::detail::GenericDefaultExtension<double> >,
-                          Acts::WeightedComponentReducerLoop,
-                          Acts::detail::VoidAuctioneer>,
-                        Acts::Navigator>;
+//using GsfPropagator = Acts::Propagator<
+//                        Acts::MultiEigenStepperLoop<
+//                          Acts::StepperExtensionList<
+//                           Acts::detail::GenericDefaultExtension<double> >,
+//                          Acts::WeightedComponentReducerLoop,
+//                          Acts::detail::VoidAuctioneer>,
+//                        Acts::Navigator>;
 
-//?!
-//using PropagatorOptions =
-//    Acts::DenseStepperPropagatorOptions<ActionList, AbortList>;
+
+using MultiStepper  = Acts::MultiEigenStepperLoop<>;
+using Propagator    = Acts::Propagator<Acts::EigenStepper<>, Acts::Navigator>;
+using GsfPropagator = Acts::Propagator<MultiStepper, Acts::Navigator>;
+using BetheHeitlerApprox = Acts::Experimental::AtlasBetheHeitlerApprox<6, 5>;
 
 namespace tracking {
 namespace reco {
 
-class CKFProcessor final : public TrackingGeometryUser {
+class GSFProcessor final : public TrackingGeometryUser {
 
  public:
   /**
@@ -114,10 +111,10 @@ class CKFProcessor final : public TrackingGeometryUser {
    * @param name The name of the instance of this object.
    * @param process The process running this producer.
    */
-  CKFProcessor(const std::string &name, framework::Process &process);
+  GSFProcessor(const std::string &name, framework::Process &process);
 
   /// Destructor
-  ~CKFProcessor();
+  ~GSFProcessor();
   
   /**
    *
@@ -153,33 +150,15 @@ class CKFProcessor final : public TrackingGeometryUser {
   
  private:
 
-  //TODO move it away
-
-  void propagateENstates(framework::Event &event,std::string inputFile, std::string outFile);
-
-  
   //Forms the layer to acts map
-  auto makeLayerSurfacesMap(std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry) const -> std::unordered_map<unsigned int, const Acts::Surface*>;
-
+  //auto makeLayerSurfacesMap(std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry) const -> std::unordered_map<unsigned int, const Acts::Surface*>;
+  
   //Make geoid -> source link map Measurements
-  auto makeGeoIdSourceLinkMap(
-      const geo::TrackersTrackingGeometry& tg,
-      const std::vector<ldmx::Measurement > &ldmxsps) -> std::unordered_multimap<Acts::GeometryIdentifier, ActsExamples::IndexSourceLink>;
-    
-    
-  //Test the magnetic field
-
-  void testField(const std::shared_ptr<Acts::MagneticFieldProvider> bField,
-                 const Acts::Vector3& eval_pos);
+  //auto makeGeoIdSourceLinkMap(
+  //    const geo::TrackersTrackingGeometry& tg,
+  //    const std::vector<ldmx::Measurement > &ldmxsps) -> std::unordered_multimap<Acts::GeometryIdentifier, ActsExamples::IndexSourceLink>;
   
-  // Make a simple event display
-  void writeEvent(framework::Event &event,
-		  const Acts::BoundTrackParameters& perigeeParameters,
-		  const Acts::MultiTrajectory<Acts::VectorMultiTrajectory>& mj,
-                  const int& trackTip,
-                  const std::vector<ldmx::Measurement> meas);
-
-  
+    
   //If we want to dump the tracking geometry
   bool dumpobj_ {false};
 
@@ -193,8 +172,18 @@ class CKFProcessor final : public TrackingGeometryUser {
   //time profiling
   std::map<std::string, double> profiling_map_;
   
+  //refitting of tracks
+  bool kf_refit_{false};
+  bool gsf_refit_{false};
+
   bool debug_{false};
+
+
+  //--- Smearing ---//
   
+  std::default_random_engine generator_;
+  std::shared_ptr<std::normal_distribution<float>> normal_;
+
   //Constant BField
   double bfield_{0};
   //Use constant bfield
@@ -209,10 +198,6 @@ class CKFProcessor final : public TrackingGeometryUser {
   //Minimum number of hits on tracks
   int min_hits_{7};
   
-  //Stepping size (in mm)
-  double propagator_step_size_{200.};
-  int propagator_maxSteps_{1000};
-  
   //The extrapolation surface
   bool use_extrapolate_location_{true};
   std::vector<double> extrapolate_location_{0.,0.,0.};
@@ -220,17 +205,16 @@ class CKFProcessor final : public TrackingGeometryUser {
   
   //The measurement collection to use for track reconstruction
   std::string measurement_collection_{"TaggerMeasurements"};
-
-  // Outlier removal pvalue
-  // The Chi2Cut is applied at filtering stage.
-  // 1DOF pvalues: 0.1 = 2.706 0.05 = 3.841 0.025 = 5.024 0.01 = 6.635 0.005 = 7.879
-  // The probability to reject a good measurement is pvalue
-  // The probability to reject an outlier is given in NIM A262 (1987) 444-450
-
+  
   double outlier_pval_{3.84};
   
   //The output track collection
-  std::string out_trk_collection_{"Tracks"};
+  std::string out_trk_collection_{"GSFTracks"};
+
+  //Select the hits using TrackID and pdg_id__
+  
+  int track_id_{-1};
+  int pdg_id_{11};
 
   //Mass for the propagator hypothesis in MeV
   double mass_{0.511};
@@ -238,42 +222,43 @@ class CKFProcessor final : public TrackingGeometryUser {
   //The seed track collection
   std::string seed_coll_name_{"seedTracks"};
 
-  //The interpolated bfield
+  
+  //The GSF Fitter
+  std::unique_ptr<
+    const Acts::Experimental::GaussianSumFitter<
+      GsfPropagator, BetheHeitlerApprox, Acts::VectorMultiTrajectory>> gsf_;
+
+  //Configuration
+  
+  std::string trackCollection_{"TaggerTracks"};
+  std::string measCollection_{"DigiTaggerSimHits"};
+    
+  size_t maxComponents_{4};
+  bool abortOnError_{false};
+  bool disableAllMaterialHandling_{false};
+  double weightCutoff_{1.0e-4};
+
+  double propagator_step_size_{200.}; //mm
+  int propagator_maxSteps_{1000};
   std::string field_map_{""};
 
-  //The Propagators
-  std::unique_ptr<const CkfPropagator> propagator_;
+  bool usePerigee_{false};
+  bool usePlaneSurface_{false};
 
-  //The CKF
-  std::unique_ptr<const Acts::CombinatorialKalmanFilter<CkfPropagator,Acts::VectorMultiTrajectory>> ckf_;
+  //The Propagators
+  std::unique_ptr<const Propagator> propagator_;
+
+  //The GSF Fitter
+  
+  //This could be a vector
+  //The mapping between layers and Acts::Surface
+  std::unordered_map<unsigned int, const Acts::Surface*> layer_surface_map_;
+
   
   //Track Extrapolator Tool
-  std::shared_ptr<tracking::reco::TrackExtrapolatorTool<CkfPropagator>> trk_extrap_ ;
-
-  //The propagator steps writer
-  std::unique_ptr<tracking::sim::PropagatorStepWriter> writer_;
-
-  //Outname of the propagator test
-  std::string steps_outfile_path_{""};
-
-  // This could be a vector
-  // The mapping between layers and Acts::Surface
-  std::unordered_map<unsigned int, const Acts::Surface*> layer_surface_map_;
-  
-  /// n seeds and n tracks
-  int nseeds_{0};
-  int ntracks_{0};
-
-  int eventnr_{0};
-
-  // BField Systematics
-  std::vector<double> map_offset_{0.,0.,0.,};
-  
-  // Keep track on which system this processor is running on
-  bool taggerTracking_{true};
-  
-  
-}; // CKFProcessor
+  std::shared_ptr<tracking::reco::TrackExtrapolatorTool<Propagator>> trk_extrap_ ;
+      
+}; // GSFProcessor
     
 
 } // namespace reco

--- a/include/Tracking/Sim/TrackingUtils.h
+++ b/include/Tracking/Sim/TrackingUtils.h
@@ -225,6 +225,18 @@ inline Acts::BoundVector boundState(const ldmx::Track& trk) {
   return paramVec;
 }
 
+inline Acts::BoundVector boundState(const ldmx::Track::TrackState& ts) {
+  Acts::BoundVector paramVec;
+  paramVec << ts.params[0],
+      ts.params[1],
+      ts.params[2],
+      ts.params[3],
+      ts.params[4],
+      ts.params[5];
+  return paramVec;
+}
+
+
 inline Acts::BoundTrackParameters boundTrackParameters(const ldmx::Track& trk,
                                                        std::shared_ptr<Acts::PerigeeSurface> perigee) {
   Acts::BoundVector paramVec  = boundState(trk);
@@ -233,8 +245,20 @@ inline Acts::BoundTrackParameters boundTrackParameters(const ldmx::Track& trk,
 }
 
 
-//Return an unbound surface along the beam axis
-inline const std::shared_ptr<Acts::Surface> unboundSurface(double surf_location) {
+inline Acts::BoundTrackParameters btp(const ldmx::Track::TrackState& ts,
+                                      std::shared_ptr<Acts::Surface> surf) {
+  
+  Acts::BoundVector paramVec = boundState(ts);
+  Acts::BoundSymMatrix covMat = unpackCov(ts.cov);
+  return Acts::BoundTrackParameters(surf,paramVec,std::move(covMat));
+  
+}
+
+
+//Return an unbound surface 
+inline const std::shared_ptr<Acts::Surface> unboundSurface(double xloc,
+                                                           double yloc = 0.,
+                                                           double zloc = 0.) {
   
   //Define the target surface - be careful:
   // x - downstream
@@ -249,7 +273,7 @@ inline const std::shared_ptr<Acts::Surface> unboundSurface(double surf_location)
   //w direction along +X
   surf_rotation(0,2) = 1;
   
-  Acts::Vector3 pos(surf_location, 0., 0.);
+  Acts::Vector3 pos(xloc, yloc, zloc);
   Acts::Translation3 surf_translation(pos);
   Acts::Transform3 surf_transform(surf_translation * surf_rotation);
   

--- a/include/Tracking/dqm/TrackingRecoDQM.h
+++ b/include/Tracking/dqm/TrackingRecoDQM.h
@@ -76,6 +76,7 @@ enum PIDBins {
     std::string truthCollection_{"TaggerTruthTracks"};
     std::string title_{"tagger_trk_"};
     double trackProb_cut_{0.5};
+    std::string subdetector_{"Tagger"};
     bool doTruthComparison{false};
     bool debug_{false};
 

--- a/python/dqm.py
+++ b/python/dqm.py
@@ -29,7 +29,7 @@ class TrackingRecoDQM(ldmxcfg.Analyzer):
     def __init__(self, name="TrackingRecoDQM"):
         super().__init__(name, 'tracking::dqm::TrackingRecoDQM',
                          'Tracking')
-
+        
         nbins    = 400
         d0min    = -15.
         d0max    =  15.

--- a/python/tracking.py
+++ b/python/tracking.py
@@ -110,12 +110,6 @@ class CKFProcessor(Producer):
         debugging purposes. <functionality to be moved>
     steps_output_file_path_ : string
         DEPRECATED TO BE REMOVED
-    track_id : int
-        <functionality to be removed>
-        Only keep the simulated hits with that particular track ID.
-    pdg_id : int
-        <functionality to be removed>
-        Only keep the simulated hits with that particular pdg ID.
     bfield : float
         <functionality to be removed>
         If using a constant bfield, this is the BZ component. 
@@ -194,6 +188,54 @@ class CKFProcessor(Producer):
         self.kf_refit = False
         self.gsf_refit = False
         self.min_hits = 6
+
+
+
+class GSFProcessor(Producer):
+    """ Producer that runs Gaussian Sum Fitter on a specific track collection
+
+    Parameters
+    ----------
+    instance_name : str
+        Unique name for this instance.
+
+    Attributes
+    ---------
+    trackCollection : string
+        Track collection to be refitted with GSF
+    measCollection  : string
+        Measurements collection in the tracker
+    maxComponents   : int
+        How many gaussians to use to sample the BetheHeitler
+    abortOnError    : bool
+        Abort fitting if an error occurred
+    disableAllMaterialHandling : bool
+        Disable material effects on surfaces. True only for debug purpose
+    weightCutOff    : double
+        Kill a component if its weight is smaller than a certain treshold.
+    propagator_step_size : float
+        Size of each RK propagator step.
+    propagator_maxSteps : int
+        Maximum number of steps for the propagator
+    field_map_ : string
+        Path to the location of the magnetic field map.
+    """
+
+    def __init__(self, instance_name='GSFProcessor'):
+        super().__init__(instance_name, 'tracking::reco::GSFProcessor',
+                         'Tracking')
+
+        self.trackCollection = "TaggerTracks"
+        self.measCollection  = "DigiTaggerSimHits"
+        self.maxComponent    = 4
+        self.abortOnError    = False
+        self.disableAllMaterialHandling = False
+        self.weightCutoff    = 1.0e-4
+
+        self.propagator_step_size = 200.
+        self.propagator_maxSteps  = 1000
+        self.field_map = makeFieldMapPath()
+
         
 
 class TruthSeedProcessor(Producer):

--- a/src/Tracking/Reco/GSFProcessor.cxx
+++ b/src/Tracking/Reco/GSFProcessor.cxx
@@ -1,0 +1,420 @@
+#include "Tracking/Reco/GSFProcessor.h"
+#include "Acts/EventData/SourceLink.hpp"
+
+#include <algorithm>
+
+namespace tracking {
+namespace reco {
+
+
+GSFProcessor::GSFProcessor(const std::string& name, framework::Process& process)
+    : TrackingGeometryUser(name, process) {
+}
+
+
+GSFProcessor::~GSFProcessor(){}
+
+void GSFProcessor::onNewRun(const ldmx::RunHeader& rh) {
+
+  // Custom transformation of the interpolated bfield map
+  bool debugTransform = false;
+  auto transformPos = [this,debugTransform](const Acts::Vector3& pos) {
+    
+    Acts::Vector3 rot_pos;
+    rot_pos(0)=pos(1);
+    rot_pos(1)=pos(2);
+    rot_pos(2)=pos(0) + DIPOLE_OFFSET;
+
+    //Apply A rotation around the center of the magnet. (I guess offset first and then rotation)
+
+    if (debugTransform) {
+      std::cout<<"PF::DEFAULT3 TRANSFORM"<<std::endl;
+      std::cout<<"PF::Check:: transforming Pos"<<std::endl;
+      std::cout<<pos<<std::endl;
+      std::cout<<"TO"<<std::endl;
+      std::cout<<rot_pos<<std::endl;
+    }
+
+    return rot_pos;
+  };
+  
+
+  Acts::RotationMatrix3 rotation = Acts::RotationMatrix3::Identity();
+  double scale = 1.;
+  
+  auto transformBField = [rotation, scale, debugTransform](const Acts::Vector3& field,
+                                           const Acts::Vector3& /*pos*/) {
+    
+    //Rotate the field in tracking coordinates
+    Acts::Vector3 rot_field;
+    rot_field(0) = field(2);
+    rot_field(1) = field(0);
+    rot_field(2) = field(1);
+
+    
+    //Scale the field
+    rot_field = scale * rot_field;
+
+    //Rotate the field
+    rot_field = rotation * rot_field;
+
+    //A distortion scaled by position.
+    
+
+    if (debugTransform) {
+      std::cout<<"PF::DEFAULT3 TRANSFORM"<<std::endl;
+      std::cout<<"PF::Check:: transforming"<<std::endl;
+      std::cout<<field<<std::endl;
+      std::cout<<"TO"<<std::endl;
+      std::cout<<rot_field<<std::endl;
+    }
+    
+    return rot_field;
+  };
+  
+  // Setup a interpolated bfield map
+  const auto map = std::make_shared<InterpolatedMagneticField3>(
+      loadDefaultBField(field_map_,
+                        //default_transformPos,
+                        //default_transformBField));
+                        transformPos,
+                        transformBField));
+
+  auto acts_loggingLevel = Acts::Logging::ERROR;
+  
+  if (debug_)
+    acts_loggingLevel = Acts::Logging::VERBOSE;
+  
+  //Setup the GSF Fitter
+  
+  // Stepper
+  //Acts::MixtureReductionMethod finalReductionMethod;
+  //const auto multi_stepper = Acts::MultiEigenStepperLoop{map};
+  
+  Acts::MixtureReductionMethod reductionMethod = Acts::MixtureReductionMethod::eMaxWeight;
+  Acts::MultiEigenStepperLoop multi_stepper(map,
+                                            reductionMethod,
+                                            Acts::getDefaultLogger("GSF_STEP",
+                                                                   acts_loggingLevel));
+  
+  // Detailed Stepper
+  
+  //Acts::MultiEigenStepperLoop multi_stepper(map, finalReductionMethod);
+  
+  // Navigator
+  Acts::Navigator::Config navCfg{geometry().getTG()};
+  navCfg.resolveMaterial  = true;
+  navCfg.resolvePassive   = false;
+  navCfg.resolveSensitive = true;
+  navCfg.boundaryCheckLayerResolving = false;
+  const Acts::Navigator navigator(navCfg);
+  
+  auto gsf_propagator = GsfPropagator(std::move(multi_stepper),
+                                      std::move(navigator),
+                                      Acts::getDefaultLogger("GSF_PROP", acts_loggingLevel));
+
+  BetheHeitlerApprox betheHeitler = Acts::Experimental::makeDefaultBetheHeitlerApprox();
+  
+  const auto gsfLogger =
+      Acts::getDefaultLogger("GSF", acts_loggingLevel);
+  
+  gsf_ =
+      std::make_unique<std::decay_t<decltype(*gsf_)>>(std::move(gsf_propagator),
+                                                      std::move(betheHeitler),
+                                                      Acts::getDefaultLogger("GSF", acts_loggingLevel));
+
+
+
+  
+  const auto stepper = Acts::EigenStepper<>{map};
+  propagator_ = std::make_unique<Propagator>(stepper,
+                                             navigator,
+                                             Acts::getDefaultLogger("PROP",acts_loggingLevel));
+  
+  trk_extrap_ = std::make_shared<std::decay_t<decltype(*trk_extrap_)>>(*propagator_,
+                                                                       geometry_context(),
+                                                                       magnetic_field_context());
+  
+  
+}
+
+
+void GSFProcessor::configure(framework::config::Parameters& parameters) {
+  
+  out_trk_collection_ = parameters.getParameter<std::string>("out_trk_collection","GSFTracks");
+  
+  maxComponents_ = parameters.getParameter<int>("maxComponents",4);
+  abortOnError_  = parameters.getParameter<bool>("abortOnError",false);
+  disableAllMaterialHandling_ = parameters.getParameter<bool>("disableAllMaterialHandling", false);
+  weightCutoff_  = parameters.getParameter<double>("weightCutoff_",1.0e-4);
+  
+  propagator_maxSteps_ =
+      parameters.getParameter<int>("propagator_maxSteps", 10000);
+  propagator_step_size_ =
+      parameters.getParameter<double>("propagator_step_size", 200.);
+  field_map_ = parameters.getParameter<std::string>("field_map");
+  usePerigee_ = parameters.getParameter<bool>("usePerigee", false);
+  
+  debug_ = parameters.getParameter<bool>("debug",false);
+  
+  //finalReductionMethod_ = parameters.getParameter<double>("finalReductionMethod",);
+    
+}
+
+
+void GSFProcessor::produce(framework::Event& event) {
+  
+  // General Setup 
+  
+  auto tg{geometry()};
+
+  // Retrieve the tracks
+  if (!event.exists(trackCollection_)) return;
+  auto tracks{event.getCollection<ldmx::Track>(trackCollection_)};
+  
+  // Retrieve the measurements
+  if (!event.exists(measCollection_)) return;
+  auto measurements{event.getCollection<ldmx::Measurement>(measCollection_)};
+  
+  
+  tracking::sim::LdmxMeasurementCalibrator calibrator{measurements};
+  
+  //GSF Setup
+  
+  Acts::GainMatrixUpdater updater;
+  Acts::Experimental::GsfExtensions<Acts::VectorMultiTrajectory> gsf_extensions;
+  gsf_extensions.updater.connect<
+    &Acts::GainMatrixUpdater::operator()<Acts::VectorMultiTrajectory>>(
+        &updater);
+  gsf_extensions.calibrator
+      .connect<&tracking::sim::LdmxMeasurementCalibrator::calibrate_1d>(&calibrator);
+  
+  
+  // Propagator Options
+  
+  //Move this at the start of the producer
+  Acts::PropagatorOptions<ActionList, AbortList> propagator_options(
+      geometry_context(), magnetic_field_context()
+                                                                    );
+  
+  propagator_options.pathLimit = std::numeric_limits<double>::max();
+  
+  // Activate loop protection at some pt value
+  propagator_options.loopProtection = false;  //(startParameters.transverseMomentum() < cfg.ptLoopers);
+  
+  // Switch the material interaction on/off & eventually into logging mode
+  auto& mInteractor =
+      propagator_options.actionList.get<Acts::MaterialInteractor>();
+  mInteractor.multipleScattering = true;
+  mInteractor.energyLoss = true;
+  mInteractor.recordInteractions = false;
+  
+  // The logger can be switched to sterile, e.g. for timing logging
+  auto& sLogger =
+      propagator_options.actionList.get<Acts::detail::SteppingLogger>();
+  sLogger.sterile = true;
+  // Set a maximum step size
+  propagator_options.maxStepSize =
+      propagator_step_size_ * Acts::UnitConstants::mm;
+  propagator_options.maxSteps = propagator_maxSteps_;
+    
+  // Electron hypothesis
+  propagator_options.mass = 0.511 * Acts::UnitConstants::MeV;
+  
+  
+  // GSF Options, to be moved out of produce loop
+  
+  std::shared_ptr<const Acts::PerigeeSurface> origin_surface =
+      Acts::Surface::makeShared<Acts::PerigeeSurface>(
+          Acts::Vector3(0., 0., 0.));
+  
+  Acts::Experimental::GsfOptions<Acts::VectorMultiTrajectory> gsfOptions{
+    geometry_context(),
+    magnetic_field_context(),
+    calibration_context(),
+    gsf_extensions,
+    propagator_options,
+    &(*origin_surface),
+    maxComponents_,
+    weightCutoff_,
+    abortOnError_,
+    disableAllMaterialHandling_};
+  
+    
+  // Output track container
+  std::vector<ldmx::Track> out_tracks;
+
+  // Acts containers
+  Acts::VectorTrackContainer vtc;
+  Acts::VectorMultiTrajectory mtj;
+  Acts::TrackContainer tc{vtc, mtj};
+  
+  // Loop on tracks
+  unsigned int itrk = 0;
+  
+  for (auto &track : tracks) {
+
+    //Retrieve measurements on track
+    std::vector<ldmx::Measurement> measOnTrack;
+    
+    //std::vector<ActsExamples::IndexSourceLink> fit_trackSourceLinks;
+    std::vector<Acts::SourceLink> fit_trackSourceLinks;
+    
+    for (auto imeas : track.getMeasurementsIdxs()) {
+      auto meas  = measurements.at(imeas);
+      measOnTrack.push_back(meas);
+      
+
+      //Retrieve the surface
+
+      const Acts::Surface* hit_surface = tg.getSurface(meas.getLayerID()); 
+
+      // Store the index source link
+      ActsExamples::IndexSourceLink idx_sl(hit_surface->geometryId(),imeas);
+      fit_trackSourceLinks.push_back(Acts::SourceLink(idx_sl));
+      
+    }
+
+    //Reverse the order of the vectors
+    std::reverse(measOnTrack.begin(), measOnTrack.end());
+    std::reverse(fit_trackSourceLinks.begin(), fit_trackSourceLinks.end());
+
+    for ( auto m : measOnTrack) {
+      ldmx_log(debug) << "Measurement:\n"<<m<<"\n";
+    }
+        
+    ldmx_log(debug) << "GSF Refitting";
+    
+    // Get the track parameters
+    
+    std::shared_ptr<Acts::PerigeeSurface> perigee =
+        Acts::Surface::makeShared<Acts::PerigeeSurface>(
+            Acts::Vector3(track.getPerigeeX(), track.getPerigeeY(), track.getPerigeeZ()));
+    
+    Acts::BoundTrackParameters trk_btp = tracking::sim::utils::boundTrackParameters(track,perigee);
+    
+    std::shared_ptr<Acts::Surface> beamOrigin_surface = tracking::sim::utils::unboundSurface(-700);
+    
+    if (!track.getTrackState(ldmx::TrackStateType::AtBeamOrigin).has_value()) {
+      lmdx_log(warn)<<"Failed retreiving AtBeamOrigin TrackState for track. Skipping..";
+      continue;
+    }
+
+    auto ts = track.getTrackState(ldmx::TrackStateType::AtBeamOrigin).value();
+    Acts::BoundTrackParameters trk_btp_bO =
+        tracking::sim::utils::btp(ts,
+                                  beamOrigin_surface);
+    
+    
+    const Acts::BoundVector& trkpars = trk_btp.parameters();
+    ldmx_log(debug)<<"CKF Track parameters"<<std::endl
+                   <<trkpars[0]<<" "<<trkpars[1]<<" "<<trkpars[2]<<" "
+                   <<trkpars[3]<<" "<<trkpars[4]<<" "<<trkpars[5]<<std::endl
+                   <<"Perigee Surface"<<std::endl
+                   <<track.getPerigeeX()<<" "<<track.getPerigeeY()<<" "<<track.getPerigeeZ();
+    
+    Acts::Vector3 trk_pos = trk_btp.position(geometry_context());
+    
+    ldmx_log(debug)<<trk_pos(0)<<" "<<trk_pos(1)<<" "<<trk_pos(2)<<std::endl;
+
+
+    const Acts::BoundVector& trkpars_bO = trk_btp_bO.parameters();   
+    ldmx_log(debug)<<"CKF BeamOrigin track parameters"<<std::endl
+                   <<trkpars_bO[0]<<" "<<trkpars_bO[1]<<" "<<trkpars_bO[2]<<" "
+                   <<trkpars_bO[3]<<" "<<trkpars_bO[4]<<" "<<trkpars_bO[5]<<" ";
+    
+    Acts::Vector3 trk_pos_bO = trk_btp_bO.position(geometry_context());
+    ldmx_log(debug)<<trk_pos_bO(0)<<" "<<trk_pos_bO(1)<<" "<<trk_pos_bO(2)<<std::endl;
+        
+    
+    auto gsf_refit_result =
+        gsf_->fit(fit_trackSourceLinks.begin(), fit_trackSourceLinks.end(),
+                  trk_btp_bO, gsfOptions,tc);
+    
+    
+    if (!gsf_refit_result.ok()) {
+      ldmx_log(warn)
+          <<"GSF re-fit failed"<<std::endl;
+      continue;
+    }
+
+    if (tc.size() < 1)
+      continue;
+    
+    auto gsftrk = tc.getTrack(itrk);
+    calculateTrackQuantities(gsftrk);
+
+    const Acts::BoundVector& perigee_pars = gsftrk.parameters();
+    const Acts::BoundMatrix& trk_cov      = gsftrk.covariance();
+    const Acts::Surface& perigee_surface  = gsftrk.referenceSurface();
+    
+    ldmx_log(debug)<<"Found track:"<<std::endl
+                  <<"Track states "<< gsftrk.nTrackStates()<<std::endl
+                  <<perigee_pars[Acts::eBoundLoc0]<<" "
+                  <<perigee_pars[Acts::eBoundLoc1]<<" "
+                  <<perigee_pars[Acts::eBoundPhi]<<" "
+                  <<perigee_pars[Acts::eBoundTheta]<<" "
+                  <<perigee_pars[Acts::eBoundQOverP]<<std::endl
+                  <<"Reference Surface"<<std::endl
+                  <<" "<<perigee_surface.transform(geometry_context()).translation()(0)
+                  <<" "<<perigee_surface.transform(geometry_context()).translation()(1)
+                  <<" "<<perigee_surface.transform(geometry_context()).translation()(2)
+                  <<std::endl;
+
+
+
+    ldmx::Track trk = ldmx::Track();
+    
+
+    //Unbounded surface
+    const std::shared_ptr<Acts::Surface> target_surface =
+        tracking::sim::utils::unboundSurface(0.);
+    
+    ldmx_log(debug)<<"Target extrapolation";
+    ldmx::Track::TrackState tsAtTarget;
+    
+    bool success = trk_extrap_->TrackStateAtSurface(gsftrk,
+                                                    target_surface,
+                                                    tsAtTarget,
+                                                    ldmx::TrackStateType::AtTarget);
+    
+    if (success)
+      trk.addTrackState(tsAtTarget);
+    
+
+    
+    trk.setPerigeeLocation(perigee_surface.transform(geometry_context()).translation()(0),
+                           perigee_surface.transform(geometry_context()).translation()(1),
+                           perigee_surface.transform(geometry_context()).translation()(2));
+    
+    trk.setChi2(gsftrk.chi2());
+    trk.setPerigeeParameters(tracking::sim::utils::convertActsToLdmxPars(perigee_pars));
+    std::vector<double> v_trk_cov;
+    tracking::sim::utils::flatCov(trk_cov, v_trk_cov);
+    trk.setPerigeeCov(v_trk_cov);
+    Acts::Vector3 trk_momentum = gsftrk.momentum();
+    trk.setMomentum(trk_momentum(0), trk_momentum(1), trk_momentum(2));
+
+    //truth information
+    trk.setTrackID(track.getTrackID());
+    trk.setPdgID(track.getPdgID());
+    trk.setTruthProb(track.getTruthProb());
+        
+
+    itrk++;
+    
+    out_tracks.push_back(trk);
+    
+  } // loop on tracks
+  
+  event.add(out_trk_collection_, out_tracks);
+  
+}
+
+void GSFProcessor::onProcessStart() {};
+void GSFProcessor::onProcessEnd() {};
+
+} // namespace reco
+} // namespace tracking
+
+DECLARE_PRODUCER_NS(tracking::reco, GSFProcessor)

--- a/src/Tracking/Reco/GSFProcessor.cxx
+++ b/src/Tracking/Reco/GSFProcessor.cxx
@@ -296,7 +296,7 @@ void GSFProcessor::produce(framework::Event& event) {
     std::shared_ptr<Acts::Surface> beamOrigin_surface = tracking::sim::utils::unboundSurface(-700);
     
     if (!track.getTrackState(ldmx::TrackStateType::AtBeamOrigin).has_value()) {
-      lmdx_log(warn)<<"Failed retreiving AtBeamOrigin TrackState for track. Skipping..";
+      ldmx_log(warn)<<"Failed retreiving AtBeamOrigin TrackState for track. Skipping..";
       continue;
     }
 

--- a/src/Tracking/dqm/TrackingRecoDQM.cxx
+++ b/src/Tracking/dqm/TrackingRecoDQM.cxx
@@ -13,8 +13,8 @@ void TrackingRecoDQM::configure(framework::config::Parameters &parameters) {
   truthCollection_ = parameters.getParameter<std::string>("truth_collection","TaggerTruthTracks");
   title_           = parameters.getParameter<std::string>("title","tagger_trk_");
   trackProb_cut_   = parameters.getParameter<double>("trackProb_cut",0.5);
-
-
+  subdetector_     = parameters.getParameter<std::string>("subdetector","Tagger");
+  
   pidmap[-321]  = PIDBins::kminus;
   pidmap[321]   = PIDBins::kplus;
   pidmap[-211]  = PIDBins::piminus;
@@ -23,8 +23,6 @@ void TrackingRecoDQM::configure(framework::config::Parameters &parameters) {
   pidmap[-11]   = PIDBins::positron;
   pidmap[2212]  = PIDBins::proton;
   pidmap[-2212] = PIDBins::antiproton;
-
-
   
 }
 
@@ -574,19 +572,19 @@ void TrackingRecoDQM::TrackTargetScoringPlaneMonitoring(const std::vector<ldmx::
   for (auto sp_hit : *(target_scoring_hits_)) {
     
     if (sp_hit.getMomentum()[2] > 0 ) {
-
+      
       // If tagger check only for scoring planes in thenegative side else check for the positive side
-      if (trackCollection_.find("Tagger") != std::string::npos) {
+      if (subdetector_.find("Tagger") != std::string::npos) {
         if (sp_hit.getPosition()[2] > 0 )
           continue;
       }
-      else if (trackCollection_.find("Recoil") != std::string::npos) {
+      else if (subdetector_.find("Recoil") != std::string::npos) {
         if (sp_hit.getPosition()[2] < 0)
           continue;
       }
       else {
-        std::cout<<"ERROR:: Unkown track collection to match to scoring plane hits"<<std::endl;
-            continue;
+        ldmx_log(error)<<"Unkown subdetector to match the scoring plane hist to tracks";
+        continue;
       }
       
       sel_target_spHits.push_back(sp_hit);


### PR DESCRIPTION
This PR brings in the possibility of refitting tracks with the use of the Gaussian Sum Filter for improved momentum estimate at target from Tagger tracks fits. 